### PR TITLE
v2.0.1

### DIFF
--- a/TF2Dodgeball/addons/sourcemod/scripting/dodgeball.sp
+++ b/TF2Dodgeball/addons/sourcemod/scripting/dodgeball.sp
@@ -19,7 +19,7 @@
 // *********************************************************************************
 #define PLUGIN_NAME             "[TF2] Dodgeball"
 #define PLUGIN_AUTHOR           "Damizean, x07x08 continued by Silorak"
-#define PLUGIN_VERSION          "2.0.0"
+#define PLUGIN_VERSION          "2.0.1"
 #define PLUGIN_CONTACT          "https://github.com/Silorak/TF2-Dodgeball-Modified"
 
 enum Musics

--- a/TF2Dodgeball/addons/sourcemod/scripting/include/dodgeball_config.inc
+++ b/TF2Dodgeball/addons/sourcemod/scripting/include/dodgeball_config.inc
@@ -141,7 +141,7 @@ public Action CmdExplosion(int iArgs)
 	GetCmdArg(1, strBuffer, sizeof(strBuffer));
 	iClient = StringToInt(strBuffer);
 
-	if (!IsValidEntity(iClient)) return Plugin_Handled;
+	if (!IsValidClient(iClient)) return Plugin_Handled;
 
 	float fPosition[3];
 	GetClientAbsOrigin(iClient, fPosition);
@@ -179,7 +179,7 @@ public Action CmdShockwave(int iArgs)
 		return Plugin_Handled;
 	}
 
-	char strBuffer[8];
+	char strBuffer[32];
 	int iClient, iTeam;
 	float fPosition[3];
 	int iDamage;
@@ -448,6 +448,12 @@ void ParseClasses(KeyValues kvConfig)
 
 		RocketClassFlags[iIndex] = iFlags;
 		RocketClassCount++;
+
+		if (RocketClassCount >= MAX_ROCKET_CLASSES)
+		{
+			LogError("Reached maximum rocket classes (%d). Remaining classes will be ignored.", MAX_ROCKET_CLASSES);
+			break;
+		}
 	}
 	while (kvConfig.GotoNextKey());
 	kvConfig.GoBack();

--- a/TF2Dodgeball/addons/sourcemod/scripting/include/dodgeball_events.inc
+++ b/TF2Dodgeball/addons/sourcemod/scripting/include/dodgeball_events.inc
@@ -102,6 +102,7 @@ public void OnPlayerDeath(Event hEvent, char[] strEventName, bool bDontBroadcast
 
 	LastDeadClient = iVictim;
 	LastDeadTeam = GetClientTeam(iVictim);
+	PlayerCount = CountAlivePlayers();
 	
 	int iInflictor = hEvent.GetInt("inflictor_entindex");
 	int iIndex = FindRocketByEntity(iInflictor);

--- a/TF2Dodgeball/addons/sourcemod/scripting/include/dodgeball_rockets.inc
+++ b/TF2Dodgeball/addons/sourcemod/scripting/include/dodgeball_rockets.inc
@@ -71,7 +71,7 @@ void CreateRocket(int iSpawnerEntity, int iSpawnerClass, int iTeam, int iClass =
 	RocketLastDeflectionTime[iIndex] = GetGameTime();
 	RocketLastBeepTime[iIndex]       = GetGameTime();
 	RocketSpeed[iIndex]              = CalculateRocketSpeed(iClass, fModifier);
-	RocketMphSpeed[iIndex]           = CalculateRocketSpeed(iClass, fModifier) * HAMMER_TO_MPH;
+	RocketMphSpeed[iIndex]           = RocketSpeed[iIndex] * HAMMER_TO_MPH;
 	Internal_SetRocketState(iIndex, RocketState_None);
 
 	CopyVectors(fDirection, RocketDirection[iIndex]);
@@ -110,7 +110,11 @@ void DestroyRocket(int iIndex)
 {
 	if (!IsValidRocket(iIndex)) return;
 
-	RemoveEdict(EntRefToEntIndex(RocketEntity[iIndex]));
+	int iEntity = EntRefToEntIndex(RocketEntity[iIndex]);
+	if (iEntity != INVALID_ENT_REFERENCE)
+	{
+		RemoveEntity(iEntity);
+	}
 	RocketIsValid[iIndex] = false;
 	RocketCount--;
 }
@@ -167,13 +171,10 @@ int FindNextValidRocket(int iIndex)
  */
 int FindFreeRocketSlot()
 {
-	int iCurrent = 0;
-	do
+	for (int iCurrent = 0; iCurrent < MAX_ROCKETS; iCurrent++)
 	{
 		if (!IsValidRocket(iCurrent)) return iCurrent;
-		if ((++iCurrent) == MAX_ROCKETS) iCurrent = 0;
 	}
-	while (iCurrent != 0);
 
 	return -1;
 }
@@ -278,7 +279,6 @@ void HomingRocketThink(int iIndex)
 				RocketTarget[iIndex]      = EntIndexToEntRef(iTarget);
 				RocketDeflections[iIndex] = iDeflectionCount;
 				RocketSpeed[iIndex]       = CalculateRocketSpeed(iClass, fModifier);
-				RocketMphSpeed[iIndex]    = CalculateRocketSpeed(iClass, fModifier) * HAMMER_TO_MPH;
 				SetEntDataFloat(iEntity, FindSendPropInfo("CTFProjectile_Rocket", "m_iDeflected") + 4, CalculateRocketDamage(iClass, fModifier), true);
 				
 				if (TestFlags(iFlags, RocketFlag_ElevateOnDeflect)) RocketInstanceFlags[iIndex] |= RocketFlag_Elevating;
@@ -287,6 +287,8 @@ void HomingRocketThink(int iIndex)
 				{
 					RocketSpeed[iIndex] = RocketClassSpeedLimit[iClass];
 				}
+
+				RocketMphSpeed[iIndex] = RocketSpeed[iIndex] * HAMMER_TO_MPH;
 
 				if (CvarStealPreventionDamage.BoolValue && (RocketInstanceState[iIndex] & RocketState_Stolen))
 				{
@@ -450,7 +452,6 @@ void RocketLegacyThink(int iIndex)
 		RocketDeflections[iIndex]        = iDeflectionCount;
 		RocketLastDeflectionTime[iIndex] = GetGameTime();
 		RocketSpeed[iIndex]              = CalculateRocketSpeed(iClass, fModifier);
-		RocketMphSpeed[iIndex]           = CalculateRocketSpeed(iClass, fModifier) * HAMMER_TO_MPH;
 		SetEntDataFloat(iEntity, FindSendPropInfo("CTFProjectile_Rocket", "m_iDeflected") + 4, CalculateRocketDamage(iClass, fModifier), true);
 
 		if (TestFlags(iFlags, RocketFlag_ElevateOnDeflect)) RocketInstanceFlags[iIndex] |= RocketFlag_Elevating;
@@ -459,6 +460,8 @@ void RocketLegacyThink(int iIndex)
 		{
 			RocketSpeed[iIndex] = RocketClassSpeedLimit[iClass];
 		}
+
+		RocketMphSpeed[iIndex] = RocketSpeed[iIndex] * HAMMER_TO_MPH;
 
 		if (CvarStealPreventionDamage.BoolValue && (RocketInstanceState[iIndex] & RocketState_Stolen))
 		{

--- a/TF2Dodgeball/addons/sourcemod/scripting/include/dodgeball_utilities.inc
+++ b/TF2Dodgeball/addons/sourcemod/scripting/include/dodgeball_utilities.inc
@@ -283,7 +283,7 @@ public Action KillParticle(Handle hTimer, any iEntityRef)
 	int iEntity = EntRefToEntIndex(iEntityRef);
 	if (iEntity != INVALID_ENT_REFERENCE)
 	{
-		RemoveEdict(iEntity);
+		RemoveEntity(iEntity);
 	}
 	
 	return Plugin_Continue;


### PR DESCRIPTION
- Use RemoveEntity instead of RemoveEdict in DestroyRocket and KillParticle
- Add null check on EntRefToEntIndex before entity removal
- Fix CmdExplosion: validate as client, not entity
- Fix CmdShockwave: increase buffer from char[8] to char[32]
- Add RocketClassCount bounds check in config parser
- Sync RocketMphSpeed with RocketSpeed after speed limit clamping
- Update PlayerCount on player death for accurate difficulty scaling
- Simplify FindFreeRocketSlot: replace do/while with for loop