### PR TITLE
Add workshop map support via GetMapDisplayName

### DIFF
--- a/TF2Dodgeball/addons/sourcemod/scripting/include/dodgeball_core.inc
+++ b/TF2Dodgeball/addons/sourcemod/scripting/include/dodgeball_core.inc
@@ -14,6 +14,7 @@ static bool EventsHooked = false;
 bool IsDodgeBallMap()
 {
 	char map[64]; GetCurrentMap(map, sizeof(map));
+	GetMapDisplayName(map, map, sizeof(map));
 	return (StrContains(map, "tfdb_", false) == 0 ||
 	        StrContains(map, "db_", false) == 0 ||
 	        StrContains(map, "dbs_", false) == 0);
@@ -28,6 +29,7 @@ void EnableDodgeBall()
 	if (Enabled) return;
 
 	char mapName[64]; GetCurrentMap(mapName, sizeof(mapName));
+	GetMapDisplayName(mapName, mapName, sizeof(mapName));
 	char mapFile[PLATFORM_MAX_PATH]; FormatEx(mapFile, sizeof(mapFile), "%s.cfg", mapName);
 
 	ParseConfigurations();


### PR DESCRIPTION
Workshop maps return paths like "workshop/454118349" or  "workshop/map_name.ugc454118349" from GetCurrentMap(), which  causes IsDodgeBallMap() prefix check to fail and the plugin  to never enable.

Added GetMapDisplayName() (SM 1.8+) calls to resolve workshop  paths to their actual map names before prefix checking in:
- IsDodgeBallMap() — map detection
- EnableDodgeBall() — per-map config file loading

No impact on non-workshop maps (returns name unchanged).