### PR TITLE
Workshop subplugins support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ built on the shoulders of community giants.
 # 1. Download the latest release
 # 2. Extract to your server's tf/ directory
 # 3. (Optional) Add subplugins from Subplugins/ folder
-# 4. Restart server or change to a tfdb_ map
+# 4. Restart server or change to a tfdb_, db_, or dbs_ map
 ```
 
 <details>
@@ -80,7 +80,7 @@ built on the shoulders of community giants.
 2. **Extract** the `addons` folder into your server's `tf/` directory
 3. **Add Subplugins** (optional): Copy desired modules from `Subplugins/` to `tf/addons/sourcemod/plugins/`
 4. **Verify Dependencies**: See [Dependencies](#-dependencies) section
-5. **Restart** your server or change to any `tfdb_` prefixed map
+5. **Restart** your server or change to any `tfdb_`, `db_`, or `dbs_` prefixed map
 
 > 📖 See the [Installation Wiki](https://github.com/Silorak/TF2-Dodgeball-Modified/wiki/Installation) for a complete guide.
 
@@ -125,7 +125,7 @@ built on the shoulders of community giants.
 └── tfdb_mapname.cfg     # Per-map overrides (optional)
 ```
 
-The gamemode activates automatically on maps with the `tfdb_` prefix.
+The gamemode activates automatically on maps with the `tfdb_`, `db_`, or `dbs_` prefix (including Workshop maps).
 
 <details>
 <summary><b>🎯 Example Rocket Class</b></summary>

--- a/Subplugins/Menu/scripting/tfdb_menu.sp
+++ b/Subplugins/Menu/scripting/tfdb_menu.sp
@@ -222,6 +222,7 @@ public void OnPluginStart()
 	if (!TFDB_IsDodgeballEnabled()) return;
 	
 	char strMapName[64]; GetCurrentMap(strMapName, sizeof(strMapName));
+	GetMapDisplayName(strMapName, strMapName, sizeof(strMapName));
 	char strMapFile[PLATFORM_MAX_PATH]; FormatEx(strMapFile, sizeof(strMapFile), "%s.cfg", strMapName);
 	
 	TFDB_OnRocketsConfigExecuted("general.cfg");
@@ -351,6 +352,7 @@ public int DodgeballMenuHandler(Menu hMenu, MenuAction iMenuActions, int iParam1
 					TFDB_DestroySpawners();
 					
 					char strMapName[64]; GetCurrentMap(strMapName, sizeof(strMapName));
+					GetMapDisplayName(strMapName, strMapName, sizeof(strMapName));
 					char strMapFile[PLATFORM_MAX_PATH]; FormatEx(strMapFile, sizeof(strMapFile), "%s.cfg", strMapName);
 					
 					TFDB_ParseConfigurations();

--- a/Subplugins/Votes/scripting/tfdb_votes.sp
+++ b/Subplugins/Votes/scripting/tfdb_votes.sp
@@ -70,6 +70,7 @@ public void OnPluginStart()
 	if (!TFDB_IsDodgeballEnabled()) return;
 	
 	char strMapName[64]; GetCurrentMap(strMapName, sizeof(strMapName));
+	GetMapDisplayName(strMapName, strMapName, sizeof(strMapName));
 	char strMapFile[PLATFORM_MAX_PATH]; FormatEx(strMapFile, sizeof(strMapFile), "%s.cfg", strMapName);
 	
 	TFDB_OnRocketsConfigExecuted("general.cfg");

--- a/TF2Dodgeball/addons/sourcemod/scripting/dodgeball.sp
+++ b/TF2Dodgeball/addons/sourcemod/scripting/dodgeball.sp
@@ -19,7 +19,7 @@
 // *********************************************************************************
 #define PLUGIN_NAME             "[TF2] Dodgeball"
 #define PLUGIN_AUTHOR           "Damizean, x07x08 continued by Silorak"
-#define PLUGIN_VERSION          "2.0.1"
+#define PLUGIN_VERSION          "2.0.2"
 #define PLUGIN_CONTACT          "https://github.com/Silorak/TF2-Dodgeball-Modified"
 
 enum Musics


### PR DESCRIPTION
## Summary
Added `GetMapDisplayName()` (SM 1.8+) to resolve workshop map paths in the 
Menu and Votes subplugins, matching the fix applied to the core plugin.
## Changes
- **tfdb_menu.sp**: Added `GetMapDisplayName` in `OnPluginStart` and the 
  "Refresh configuration" menu handler so per-map configs load correctly 
  on workshop maps
- **tfdb_votes**: Added `GetMapDisplayName` in `OnPluginStart` for 
  the same reason
## Why
`GetCurrentMap()` returns `workshop/454118349` on workshop maps. Without 
`GetMapDisplayName`, these subplugins would look for `workshop/454118349.cfg` 
instead of `tfdb_mapname.cfg`, silently failing to load  #per-map configs.
No impact on non-workshop maps.